### PR TITLE
DWN-2770 disable default features for error-chain

### DIFF
--- a/aerospike-core/Cargo.toml
+++ b/aerospike-core/Cargo.toml
@@ -13,7 +13,7 @@ base64 = "0.13"
 crossbeam-queue = "0.3"
 rand = "0.8"
 lazy_static = "1.4"
-error-chain = "0.12"
+error-chain = {  version = "0.12.4", default-features = false }
 pwhash = "1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 aerospike-rt = {path = "../aerospike-rt"}


### PR DESCRIPTION
error-chain uses the default feature 'backtrace' to always create backtraces with its error messages. To disable this feature, disable default-features in the cargo file. 